### PR TITLE
Guard admin detection helper usage in theme script

### DIFF
--- a/dist/admin-detector.js
+++ b/dist/admin-detector.js
@@ -6,13 +6,15 @@
   function isAdminPage() {
     const url = window.location.href;
     const pathname = window.location.pathname;
-    
-    return url.includes('/admin') || 
+
+    return url.includes('/admin') ||
            pathname.includes('/admin') ||
            document.title.includes('Admin') ||
            document.title.includes('管理') ||
            document.body.className.includes('admin');
   }
+
+  window.isAdminPage = isAdminPage;
   
   // 如果是管理页面，禁用主题
   if (isAdminPage()) {

--- a/dist/exia-script.js
+++ b/dist/exia-script.js
@@ -12,7 +12,14 @@
   // 等待DOM加载完成
   function initExiaTheme() {
     // 检查是否是管理页面
-    if (isAdminPage()) {
+    const isAdminResult = window.isAdminPage?.();
+
+    if (isAdminResult === undefined) {
+      console.warn('⚠️ 管理页面检测器不可用，跳过主题应用');
+      return;
+    }
+
+    if (isAdminResult) {
       console.log('🔧 检测到管理页面，跳过主题应用');
       return;
     }


### PR DESCRIPTION
## Summary
- expose the admin page detector globally so other scripts can reuse it
- guard the Exia theme initialization when the detector helper is unavailable

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68dc1f6ce820833294e6c09dba5455da